### PR TITLE
Added the dependency requirement that yarl < 1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp==3.3.0
 python-box==3.2.0
 requests==2.18.4
+yarl==1.1.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license='MIT',
     url='https://github.com/cgrok/clashroyale',
     keywords=['clashroyale', 'wrapper', 'cr', 'royaleapi'],
-    install_requires=['aiohttp>=2.0.0,<2.3.0', 'python-box==3.1.1', 'requests==2.18.4', 'asynctest==0.12.0'],
+    install_requires=['aiohttp>=2.0.0,<2.3.0', 'python-box==3.1.1', 'requests==2.18.4', 'asynctest==0.12.0', 'yarl<1.2'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This is to prevent an aiohttp error with a breaking change in yarl 1.2.

Resolves #14 