### PR TITLE
Updated URLs to match the latest endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 06/11/2019
+
+### Fixed
+- RoyaleAPI: Updated the endpoints URLs to match the latest version of the API. This affects all endpoints for players and clans.
+
 ## [4.0.2] - 14/04/2019
 
 ### Added

--- a/clashroyale/royaleapi/client.py
+++ b/clashroyale/royaleapi/client.py
@@ -599,7 +599,7 @@ class Client:
         return self._get_model(url, PartialClan, **params)
 
     @typecasted
-    def get_top_clans(self, country_key='', **params: keys):
+    def get_top_clans(self, country_key='all', **params: keys):
         """Get a list of top clans by trophy
 
         location_id: Optional[str] = ''
@@ -624,7 +624,7 @@ class Client:
         return self._get_model(url, PartialClan, **params)
 
     @typecasted
-    def get_top_war_clans(self, country_key='', **params: keys):
+    def get_top_war_clans(self, country_key='all', **params: keys):
         """Get a list of top clans by war
 
         location_id: Optional[str] = ''
@@ -649,7 +649,7 @@ class Client:
         return self._get_model(url, PartialClan, **params)
 
     @typecasted
-    def get_top_players(self, country_key='', **params: keys):
+    def get_top_players(self, country_key='all', **params: keys):
         """Get a list of top players
 
         location_id: Optional[str] = ''

--- a/clashroyale/royaleapi/utils.py
+++ b/clashroyale/royaleapi/utils.py
@@ -103,8 +103,8 @@ def _to_camel_case(snake):
 class API:
     def __init__(self, url):
         self.BASE = url
-        self.PLAYER = self.BASE + '/players'
-        self.CLAN = self.BASE + '/clans'
+        self.PLAYER = self.BASE + '/player'
+        self.CLAN = self.BASE + '/clan'
         self.TOURNAMENT = self.BASE + '/tournaments'
         self.TOP = self.BASE + '/top'
         self.POPULAR = self.BASE + '/popular'

--- a/tests/royaleapi/test_async.py
+++ b/tests/royaleapi/test_async.py
@@ -170,9 +170,9 @@ class TestAsyncClient(asynctest.TestCase):
 
         get_clan_history = self.cr.get_clan_history
 
-        tag = '2U2GGQJ'
+        tag = '9PJ82CRC'
         history = await get_clan_history(tag)
-        self.assertTrue(isinstance(history.raw_data, dict))
+        self.assertTrue(isinstance(history, list))
 
         tag = '000000'
 
@@ -189,13 +189,16 @@ class TestAsyncClient(asynctest.TestCase):
 
         get_clan_tracking = self.cr.get_clan_tracking
 
-        tag = '2U2GGQJ'
+        tag = '2GJU9Y2G'
         history = await get_clan_tracking(tag)
         self.assertTrue(history.available)
 
         tag = '000000'
-        history = await get_clan_tracking(tag)
-        self.assertFalse(history.available)
+
+        async def request():
+            await get_clan_tracking(tag)
+
+        self.assertAsyncRaises(clashroyale.NotTrackedError, request)
 
     async def test_get_tracking_clans(self):
         """This test will test out:

--- a/tests/royaleapi/test_blocking.py
+++ b/tests/royaleapi/test_blocking.py
@@ -164,9 +164,9 @@ class TestBlockingClient(unittest.TestCase):
 
         get_clan_history = self.cr.get_clan_history
 
-        tag = '2U2GGQJ'
+        tag = '9PJ82CRC'
         history = get_clan_history(tag)
-        self.assertTrue(isinstance(history.raw_data, dict))
+        self.assertTrue(isinstance(history, list))
 
         tag = '000000'
         self.assertRaises(clashroyale.NotTrackedError, get_clan_history, tag)
@@ -179,13 +179,12 @@ class TestBlockingClient(unittest.TestCase):
 
         get_clan_tracking = self.cr.get_clan_tracking
 
-        tag = '2U2GGQJ'
+        tag = '2GJU9Y2G'
         history = get_clan_tracking(tag)
         self.assertTrue(history.available)
 
         tag = '000000'
-        history = get_clan_tracking(tag)
-        self.assertFalse(history.available)
+        self.assertRaises(clashroyale.NotTrackedError, get_clan_tracking, tag)
 
     def test_get_tracking_clans(self):
         """This test will test out:


### PR DESCRIPTION

<!---Thank you for contributing to the clashroyale project! --->

# Changes Description
Updated URLs to match the latest endpoints

- `/clans/<TAG>/<endpoint>` and `/players/<TAG>/<endpoint>` are no longer valid and have moved to `/clan/` and `/player/`
- `/top/clans/` and `/top/players/` have moved to `/top/clans/all` and `/top/players/all`

# Type of PR
- [X] Bug Fix
<s>[ ] Feature Addition</s>

# Checklist
- [ ] Docstrings added ([NumpyDoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard))
- [ ] If necessary, add to the documentation files
- [x] Add to the CHANGELOG file
- [x] Tox checked
