### PR TITLE
Fix crtag length validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 06/11/2019
+## 09/11/2019
 
 ### Fixed
 - RoyaleAPI: Updated the endpoints URLs to match the latest version of the API. This affects all endpoints for players and clans.
+- utils: function `crtag()` used to validate tag's length and characters will now accept tags with length from 3 to 8 characteres
 
 ## [4.0.2] - 14/04/2019
 

--- a/clashroyale/official_api/utils.py
+++ b/clashroyale/official_api/utils.py
@@ -72,8 +72,8 @@ def crtag(tag):
             bad.append(c)
     if bad:
         raise ValueError('Invalid tag characters passed: {}'.format(', '.join(bad)))
-    if len(tag[3:]) < 3:
-        raise ValueError('Tag ({}) too short, length {}, expected 3'.format(tag[3:], len(tag[3:])))
+    if len(tag) < 3:
+        raise ValueError('Tag ({}) too short, length {}, expected 3'.format(tag, len(tag)))
     return tag
 
 

--- a/clashroyale/royaleapi/utils.py
+++ b/clashroyale/royaleapi/utils.py
@@ -81,8 +81,8 @@ def crtag(tag):
             bad.append(c)
     if bad:
         raise ValueError('Invalid tag characters passed: {}'.format(', '.join(bad)))
-    if len(tag[3:]) < 3:
-        raise ValueError('Tag ({}) too short, length {}, expected 3'.format(tag[3:], len(tag[3:])))
+    if len(tag) < 3:
+        raise ValueError('Tag ({}) too short, length {}, expected 3'.format(tag, len(tag)))
     return tag
 
 


### PR DESCRIPTION
<!---Thank you for contributing to the clashroyale project! --->

# Changes Description
Current behaviour:
```python
>>> player = api_client.get_player('8029R')
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "clashroyale/royaleapi/utils.py", line 30, in wrapper
    new_args.append(converter(a))
  File "clashroyale/royaleapi/utils.py", line 85, in crtag
    raise ValueError('Tag ({}) too short, length {}, expected 3'.format(tag[3:], len(tag[3:])))
ValueError: Tag (9R) too short, length 2, expected 3
```

Expected behaviour:
```python
>>> player = api_client.get_player('8029R')
>>> player.name
'mickey'
```

# Type of PR
- [x] Bug Fix
- [ ] Feature Addition

# Checklist
- [ ] Docstrings added ([NumpyDoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard))
- [ ] If necessary, add to the documentation files
- [x] Add to the CHANGELOG file
- [x] Tox checked
