### PR TITLE
OfficialAPI: add river race and river race log endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 15/09/2020
+
+### Added
+- OfficialAPI: Added `get_clan_river_race` and `get_clan_river_race_log`
+
 ## 09/11/2019
 
 ### Fixed

--- a/clashroyale/official_api/client.py
+++ b/clashroyale/official_api/client.py
@@ -244,7 +244,7 @@ class Client:
         Parameters
         ----------
         tag: str
-            A valid tournament tag. Minimum length: 3
+            A valid player tag. Minimum length: 3
             Valid characters: 0289PYLQGRJCUV
         timeout: Optional[int] = None
             Custom timeout that overwrites Client.timeout
@@ -263,7 +263,7 @@ class Client:
         Parameters
         ----------
         tag: str
-            A valid tournament tag. Minimum length: 3
+            A valid player tag. Minimum length: 3
             Valid characters: 0289PYLQGRJCUV
         apikey: str
             The API Key in the player's settings
@@ -280,7 +280,7 @@ class Client:
         Parameters
         ----------
         tag: str
-            A valid tournament tag. Minimum length: 3
+            A valid player tag. Minimum length: 3
             Valid characters: 0289PYLQGRJCUV
         \*\*limit: Optional[int] = None
             Limit the number of items returned in the response
@@ -297,7 +297,7 @@ class Client:
         Parameters
         ----------
         tag: str
-            A valid tournament tag. Minimum length: 3
+            A valid player tag. Minimum length: 3
             Valid characters: 0289PYLQGRJCUV
         timeout: Optional[int] = None
             Custom timeout that overwrites Client.timeout
@@ -312,7 +312,7 @@ class Client:
         Parameters
         ----------
         tag: str
-            A valid tournament tag. Minimum length: 3
+            A valid clan tag. Minimum length: 3
             Valid characters: 0289PYLQGRJCUV
         timeout: Optional[int] = None
             Custom timeout that overwrites Client.timeout
@@ -350,18 +350,18 @@ class Client:
         return self._get_model(url, PartialClan, **params)
 
     @typecasted
-    def get_clan_war(self, tag: crtag, timeout: int=None):
-        """Get inforamtion about a clan's current clan war
+    def get_clan_river_race(self, tag: crtag, timeout: int = None):
+        """Get inforamtion about a clan's current river race
 
         Parameters
         ----------
         tag: str
-            A valid tournament tag. Minimum length: 3
+            A valid clan tag. Minimum length: 3
             Valid characters: 0289PYLQGRJCUV
         timeout: Optional[int] = None
             Custom timeout that overwrites Client.timeout
         """
-        url = self.api.CLAN + '/' + tag + '/currentwar'
+        url = self.api.CLAN + '/' + tag + '/currentriverrace'
         return self._get_model(url, timeout=timeout)
 
     @typecasted
@@ -371,7 +371,7 @@ class Client:
         Parameters
         ----------
         tag: str
-            A valid tournament tag. Minimum length: 3
+            A valid clan tag. Minimum length: 3
             Valid characters: 0289PYLQGRJCUV
         \*\*limit: Optional[int] = None
             Limit the number of items returned in the response
@@ -388,7 +388,7 @@ class Client:
         Parameters
         ----------
         tag: str
-            A valid tournament tag. Minimum length: 3
+            A valid clan tag. Minimum length: 3
             Valid characters: 0289PYLQGRJCUV
         \*\*limit: Optional[int] = None
             Limit the number of items returned in the response
@@ -396,6 +396,23 @@ class Client:
             Custom timeout that overwrites Client.timeout
         """
         url = self.api.CLAN + '/' + tag + '/warlog'
+        return self._get_model(url, **params)
+
+    @typecasted
+    def get_clan_river_race_log(self, tag: crtag, **params: keys):
+        """Get a clan's river race log
+
+        Parameters
+        ----------
+        tag: str
+            A valid clan tag. Minimum length: 3
+            Valid characters: 0289PYLQGRJCUV
+        \*\*limit: Optional[int] = None
+            Limit the number of items returned in the response
+        \*\*timeout: Optional[int] = None
+            Custom timeout that overwrites Client.timeout
+        """
+        url = self.api.CLAN + '/' + tag + '/riverracelog'
         return self._get_model(url, **params)
 
     @typecasted

--- a/tests/official_api/test_async.py
+++ b/tests/official_api/test_async.py
@@ -79,8 +79,8 @@ class TestAsyncClient(asynctest.TestCase):
         await clans.all_data()
         self.assertGreater(len(clans), 3)
 
-    async def test_get_clan_war(self):
-        clan = await self.cr.get_clan_war(self.clan_tags[0])
+    async def test_get_clan_river_race(self):
+        clan = await self.cr.get_clan_river_race(self.clan_tags[0])
         self.assertTrue(isinstance(clan.state, str))
 
     async def test_get_clan_war_timeout(self):
@@ -97,6 +97,10 @@ class TestAsyncClient(asynctest.TestCase):
 
     async def test_get_clan_war_log(self):
         clan = await self.cr.get_clan_war_log(self.clan_tags[0])
+        self.assertTrue(isinstance(clan, clashroyale.official_api.PaginatedAttrDict))
+
+    async def test_get_clan_river_race_log(self):
+        clan = await self.cr.get_clan_river_race_log(self.clan_tags[0])
         self.assertTrue(isinstance(clan, clashroyale.official_api.PaginatedAttrDict))
 
     async def test_get_clan_war_log_timeout(self):

--- a/tests/official_api/test_blocking.py
+++ b/tests/official_api/test_blocking.py
@@ -82,8 +82,8 @@ class TestBlockingClient(unittest.TestCase):
         clans.all_data()
         self.assertGreater(len(clans), 3)
 
-    def test_get_clan_war(self):
-        clan = self.cr.get_clan_war(self.clan_tags[0])
+    def test_get_clan_river_race(self):
+        clan = self.cr.get_clan_river_race(self.clan_tags[0])
         self.assertTrue(isinstance(clan.state, str))
 
     def test_get_clan_war_timeout(self):
@@ -100,6 +100,10 @@ class TestBlockingClient(unittest.TestCase):
 
     def test_get_clan_war_log(self):
         clan = self.cr.get_clan_war_log(self.clan_tags[0])
+        self.assertTrue(isinstance(clan, clashroyale.official_api.PaginatedAttrDict))
+
+    def test_get_clan_river_race_log(self):
+        clan = self.cr.get_clan_river_race_log(self.clan_tags[0])
         self.assertTrue(isinstance(clan, clashroyale.official_api.PaginatedAttrDict))
 
     def test_get_clan_war_log_timeout(self):


### PR DESCRIPTION
<!---Thank you for contributing to the clashroyale project! --->

# Changes Description
Update war logs URL to match the latest version of Clash Royale
Given that the endpoint data format for river races slightly differs from previous clan wars, I advocate for new methods over modificating `get_clan_war*` methods.

# Type of PR
- [ ] Bug Fix
- [x] Feature Addition

# Checklist
- [x] Docstrings added ([NumpyDoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard))
- [ ] <s>If necessary, add to the documentation files</s>
- [X] Add to the CHANGELOG file
- [X] Tox checked
